### PR TITLE
Prepare for Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
-    "symfony/validator": ">=3.4"
+    "php": ">=7.2",
+    "symfony/validator": ">=5.4"
   },
   "require-dev": {
     "phpunit/phpunit": ">=6.5.14",

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
-    "symfony/validator": ">=5.4"
+    "php": ">=8.1",
+    "symfony/validator": ">=6.1"
   },
   "require-dev": {
     "phpunit/phpunit": ">=6.5.14",

--- a/src/Validator/Constraints/Nip.php
+++ b/src/Validator/Constraints/Nip.php
@@ -25,7 +25,7 @@ class Nip extends Constraint
     const INVALID_PATTERN_ERROR = 'b2e5a844-1127-43dd-be56-861a5e37fd8e';
     const INVALID_CHECKSUM_ERROR = 'ba94bb8a-88bc-4be8-9577-f71ec17cd7e7';
 
-    protected static $errorNames = [
+    protected const ERROR_NAMES = [
         self::INVALID_PATTERN_ERROR => 'INVALID_PATTERN_ERROR',
         self::INVALID_CHECKSUM_ERROR => 'INVALID_CHECKSUM_ERROR',
     ];


### PR DESCRIPTION
Symfony 6 introduced a new deprecation:

```
The "Symfony\Component\Validator\Constraint::$errorNames" property is considered final. You should not override it in "Kreyu\Bundle\NipValidatorBundle\Validator\Constraints\Nip".
```

I think the simplest route to address it would be bumping to Sf 6 (and PHP 8.1 while on it) and releasing it as a major version for BC break. WDYT?